### PR TITLE
Add meaningful title to all pages

### DIFF
--- a/src/Containers/MobileTriggerContainer.jsx
+++ b/src/Containers/MobileTriggerContainer.jsx
@@ -35,6 +35,7 @@ class TriggerContainer extends React.Component<Props, State> {
     };
 
     componentDidMount() {
+        document.title = "Moira - Trigger";
         this.getData(this.props);
     }
 
@@ -144,6 +145,8 @@ class TriggerContainer extends React.Component<Props, State> {
                 this.changeLocationSearch({ page: rightLastPage });
                 return;
             }
+
+            document.title = `Moira - Trigger - ${trigger.name}`;
 
             this.setState({
                 trigger,

--- a/src/Containers/MobileTriggerListContainer.jsx
+++ b/src/Containers/MobileTriggerListContainer.jsx
@@ -44,6 +44,7 @@ class TriggerListContainer extends React.Component<Props, State> {
     };
 
     componentDidMount() {
+        document.title = "Moira - Triggers";
         this.getData(this.props);
     }
 

--- a/src/Containers/NotificationListContainer.jsx
+++ b/src/Containers/NotificationListContainer.jsx
@@ -30,6 +30,7 @@ class NotificationListContainer extends React.Component<Props, State> {
     };
 
     componentDidMount() {
+        document.title = "Moira - Notifications";
         this.fetch(this.props);
     }
 

--- a/src/Containers/PatternListContainer.jsx
+++ b/src/Containers/PatternListContainer.jsx
@@ -24,6 +24,7 @@ class PatternListContainer extends React.Component<Props, State> {
     };
 
     componentDidMount() {
+        document.title = "Moira - Patterns";
         this.getData(this.props);
     }
 

--- a/src/Containers/SettingsContainer.jsx
+++ b/src/Containers/SettingsContainer.jsx
@@ -35,6 +35,7 @@ class SettingsContainer extends React.Component<Props, State> {
     };
 
     componentDidMount() {
+        document.title = "Moira - Settings";
         this.getData();
     }
 

--- a/src/Containers/TagListContainer.jsx
+++ b/src/Containers/TagListContainer.jsx
@@ -27,6 +27,7 @@ class TagListContainer extends React.Component<Props, State> {
     };
 
     componentDidMount() {
+        document.title = "Moira - Tags";
         this.getData(this.props);
     }
 

--- a/src/Containers/TriggerAddContainer.jsx
+++ b/src/Containers/TriggerAddContainer.jsx
@@ -68,6 +68,7 @@ class TriggerEditContainer extends React.Component<Props, State> {
     }
 
     componentDidMount() {
+        document.title = "Moira - Add trigger";
         this.getData(this.props);
     }
 

--- a/src/Containers/TriggerContainer.jsx
+++ b/src/Containers/TriggerContainer.jsx
@@ -54,6 +54,7 @@ class TriggerContainer extends React.Component<Props, State> {
     };
 
     componentDidMount() {
+        document.title = "Moira - Trigger";
         this.getData(this.props);
     }
 
@@ -230,6 +231,8 @@ class TriggerContainer extends React.Component<Props, State> {
                 const rightLastPage = Math.ceil(triggerEvents.total / triggerEvents.size) || 1;
                 this.changeLocationSearch({ page: rightLastPage });
             }
+
+            document.title = `Moira - Trigger - ${trigger.name}`;
 
             this.setState({
                 config,

--- a/src/Containers/TriggerDuplicateContainer.jsx
+++ b/src/Containers/TriggerDuplicateContainer.jsx
@@ -40,6 +40,7 @@ class TriggerDuplicateContainer extends React.Component<Props, State> {
     }
 
     componentDidMount() {
+        document.title = "Moira - Duplicate trigger";
         this.getData(this.props);
     }
 

--- a/src/Containers/TriggerEditContainer.jsx
+++ b/src/Containers/TriggerEditContainer.jsx
@@ -41,6 +41,7 @@ class TriggerEditContainer extends React.Component<Props, State> {
     }
 
     componentDidMount() {
+        document.title = "Moira - Edit trigger";
         this.getData(this.props);
     }
 

--- a/src/Containers/TriggerListContainer.jsx
+++ b/src/Containers/TriggerListContainer.jsx
@@ -53,6 +53,7 @@ class TriggerListContainer extends React.Component<Props, State> {
     };
 
     componentDidMount() {
+        document.title = "Moira - Triggers";
         this.getData(this.props);
     }
 


### PR DESCRIPTION
Добавит заголовки страниц в `title` вместо стандартного «Moira». Пока "стандартным" сопособом. Возможно, придётся использовать стороннюю библиотеку, вроде [react-document-title](https://github.com/gaearon/react-document-title)