### PR TITLE
[Fix] Removed duplicate entry of test tag in fakeapi/db.json

### DIFF
--- a/fakeapi/db.json
+++ b/fakeapi/db.json
@@ -61,7 +61,6 @@
             "archive",
             "dev",
             "moira-dev",
-            "test",
             "moira-test",
             "seyren",
             "Moira"


### PR DESCRIPTION
**Details**
Removed duplicate entry of tag "test" in the tag->list array of fakeapi/db.json. The same caused the error "2 elements having same key" when rendering the list.

**Related issues**
[moira-alert/moira#406](https://github.com/moira-alert/moira/issues/406)