### PR TITLE
fix: Remove extra parentheses from Notifications page

### DIFF
--- a/src/Containers/NotificationListContainer.jsx
+++ b/src/Containers/NotificationListContainer.jsx
@@ -51,7 +51,7 @@ class NotificationListContainer extends React.Component<Props, State> {
             <Layout loading={loading} error={error}>
                 <LayoutContent>
                     <LayoutTitle>
-                        Notifications ({Array.isArray(list) ? `(${list.length})` : null})
+                        Notifications {Array.isArray(list) ? `(${list.length})` : null}
                     </LayoutTitle>
                     {list && (
                         <NotificationList


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1009675/75559544-776c3b80-5a65-11ea-8372-f4b071819466.png)
