### PR TITLE
[FEAT] Events Expand Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "react-hot-loader": "4.8.0",
         "react-router": "5.1.2",
         "react-router-dom": "5.1.2",
+        "react-scroll-up-button": "^1.6.4",
         "react-ui-validations": "0.3.0",
         "remarkable": "1.7.1",
         "retail-ui": "0.44.1"

--- a/src/Api/MoiraApi.js
+++ b/src/Api/MoiraApi.js
@@ -105,7 +105,7 @@ export default class MoiraApi implements IMoiraApi {
 
     triggerListPageSize: number = 20;
 
-    eventHistoryPageSize: number = 0;
+    eventHistoryPageSize: number = -1;
 
     constructor(apiUrl: string) {
         this.apiUrl = apiUrl;

--- a/src/Api/MoiraApi.js
+++ b/src/Api/MoiraApi.js
@@ -105,7 +105,7 @@ export default class MoiraApi implements IMoiraApi {
 
     triggerListPageSize: number = 20;
 
-    eventHistoryPageSize: number = -1;
+    eventHistoryPageSize: number = 0;
 
     constructor(apiUrl: string) {
         this.apiUrl = apiUrl;

--- a/src/Api/MoiraApi.js
+++ b/src/Api/MoiraApi.js
@@ -105,7 +105,7 @@ export default class MoiraApi implements IMoiraApi {
 
     triggerListPageSize: number = 20;
 
-    eventHistoryPageSize: number = 100;
+    eventHistoryPageSize: number = 0;
 
     constructor(apiUrl: string) {
         this.apiUrl = apiUrl;

--- a/src/Components/EventList/EventList.jsx
+++ b/src/Components/EventList/EventList.jsx
@@ -1,11 +1,8 @@
 // @flow
 import * as React from "react";
-import moment from "moment";
-import ArrowBoldRightIcon from "@skbkontur/react-icons/ArrowBoldRight";
 import type { Event } from "../../Domain/Event";
-import StatusIndicator from "../StatusIndicator/StatusIndicator";
-import roundValue from "../../helpers/roundValue";
 import cn from "./EventList.less";
+import MetricEvents from "../MetricEvents/MetricEvents";
 
 type Props = {|
     items: {
@@ -21,37 +18,11 @@ export default function EventList(props: Props): React.Node {
                 <div className={cn("name")}>Metric</div>
                 <div className={cn("state-change")}>State change</div>
                 <div className={cn("date")}>Event time</div>
+                <div className={cn("dropdown")} />
             </div>
             {Object.keys(items).map(key => (
                 <div key={key} className={cn("group")}>
-                    {items[key].map(({ old_state: oldState, state, timestamp, value }, i) => {
-                        const oldValue = items[key][i + 1] && items[key][i + 1].value;
-                        return (
-                            <div key={`${key}-${timestamp}`} className={cn("row")}>
-                                <div className={cn("name")}>{i === 0 && key}</div>
-                                <div className={cn("state-change")}>
-                                    <div className={cn("prev-value")}>
-                                        {roundValue(oldValue, false)}
-                                    </div>
-                                    <div className={cn("prev-state")}>
-                                        <StatusIndicator statuses={[oldState]} size={14} />
-                                    </div>
-                                    <div className={cn("arrow")}>
-                                        <ArrowBoldRightIcon />
-                                    </div>
-                                    <div className={cn("curr-state")}>
-                                        <StatusIndicator statuses={[state]} size={14} />
-                                    </div>
-                                    <div className={cn("curr-value")}>
-                                        {roundValue(value, false)}
-                                    </div>
-                                </div>
-                                <div className={cn("date")}>
-                                    {moment.unix(timestamp).format("MMMM D, HH:mm:ss")}
-                                </div>
-                            </div>
-                        );
-                    })}
+                    <MetricEvents metricName={key} events={items[key]} />
                 </div>
             ))}
         </section>

--- a/src/Components/EventList/EventList.jsx
+++ b/src/Components/EventList/EventList.jsx
@@ -6,7 +6,7 @@ import MetricEvents from "../MetricEvents/MetricEvents";
 
 type Props = {|
     items: {
-        [key: string]: Array<Event>,
+        [key: string]: Array<Array<Event>, Number>,
     },
 |};
 
@@ -17,12 +17,13 @@ export default function EventList(props: Props): React.Node {
             <div className={cn("row", "header")}>
                 <div className={cn("name")}>Metric</div>
                 <div className={cn("state-change")}>State change</div>
+                <div className={cn("count")}>Events count</div>
                 <div className={cn("date")}>Event time</div>
                 <div className={cn("dropdown")} />
             </div>
             {Object.keys(items).map(key => (
                 <div key={key} className={cn("group")}>
-                    <MetricEvents metricName={key} events={items[key]} />
+                    <MetricEvents metricName={key} events={items[key][0]} count={items[key][1]} />
                 </div>
             ))}
         </section>

--- a/src/Components/EventList/EventList.jsx
+++ b/src/Components/EventList/EventList.jsx
@@ -1,5 +1,6 @@
 // @flow
 import * as React from "react";
+import ScrollUpButton from "react-scroll-up-button";
 import type { Event } from "../../Domain/Event";
 import cn from "./EventList.less";
 import MetricEvents from "../MetricEvents/MetricEvents";
@@ -20,6 +21,7 @@ export default function EventList(props: Props): React.Node {
                 <div className={cn("count")}>Events count</div>
                 <div className={cn("date")}>Event time</div>
                 <div className={cn("dropdown")} />
+                {<ScrollUpButton style={{ width: 45, height: 45 }} />}
             </div>
             {Object.keys(items).map(key => (
                 <div key={key} className={cn("group")}>

--- a/src/Components/EventList/EventList.less
+++ b/src/Components/EventList/EventList.less
@@ -49,6 +49,11 @@
     width: 200px;
 }
 
+.count {
+    flex-shrink: 0;
+    width: 200px;
+}
+
 .dropdown {
     flex-shrink: 0;
     width: 50px;

--- a/src/Components/MetricEvents/MetricEvents.jsx
+++ b/src/Components/MetricEvents/MetricEvents.jsx
@@ -13,6 +13,7 @@ import type { Event } from "../../Domain/Event";
 type Props = {|
     metricName: string,
     events: Array<Event>,
+    count: Number,
 |};
 
 type State = {
@@ -30,7 +31,7 @@ class MetricEvents extends React.Component<Props, State> {
     }
 
     render(): React.Node {
-        const { events, metricName } = this.props;
+        const { events, metricName, count } = this.props;
         const { expand } = this.state;
 
         return events.map(({ old_state: oldState, state, timestamp, value }, i) => {
@@ -61,6 +62,7 @@ class MetricEvents extends React.Component<Props, State> {
                                 </div>
                                 <div className={cn("curr-value")}>{roundValue(value, false)}</div>
                             </div>
+                            <div className={cn("count")}>{i === 0 && count}</div>
                             <div className={cn("date")}>
                                 {moment.unix(timestamp).format("MMMM D, HH:mm:ss")}
                             </div>

--- a/src/Components/MetricEvents/MetricEvents.jsx
+++ b/src/Components/MetricEvents/MetricEvents.jsx
@@ -1,0 +1,92 @@
+// @flow
+import * as React from "react";
+import moment from "moment";
+import ArrowBoldRightIcon from "@skbkontur/react-icons/ArrowBoldRight";
+import ArrowChecvronDownIcon from "@skbkontur/react-icons/ArrowChevronDown";
+import ArrowChecvronUpIcon from "@skbkontur/react-icons/ArrowChevronUp";
+import Button from "retail-ui/components/Button";
+import roundValue from "../../helpers/roundValue";
+import StatusIndicator from "../StatusIndicator/StatusIndicator";
+import cn from "./MetricEvents.less";
+import type { Event } from "../../Domain/Event";
+
+type Props = {|
+    metricName: string,
+    events: Array<Event>,
+|};
+
+type State = {
+    expand: Boolean,
+};
+
+class MetricEvents extends React.Component<Props, State> {
+    state: State;
+
+    constructor(props: Props) {
+        super(props);
+        this.state = {
+            expand: false,
+        };
+    }
+
+    render(): React.Node {
+        const { events, metricName } = this.props;
+        const { expand } = this.state;
+
+        return events.map(({ old_state: oldState, state, timestamp, value }, i) => {
+            const oldValue = events[i + 1] && events[i + 1].value;
+            let arrowIcon;
+            if (!expand) {
+                arrowIcon = <ArrowChecvronDownIcon />;
+            } else {
+                arrowIcon = <ArrowChecvronUpIcon />;
+            }
+            return (
+                (i === 0 || expand) && (
+                    <div key={`${metricName}-${timestamp}`} className={cn("row")}>
+                        <div className={cn("name")}>{i === 0 && metricName}</div>
+                        <>
+                            <div className={cn("state-change")}>
+                                <div className={cn("prev-value")}>
+                                    {roundValue(oldValue, false)}
+                                </div>
+                                <div className={cn("prev-state")}>
+                                    <StatusIndicator statuses={[oldState]} size={14} />
+                                </div>
+                                <div className={cn("arrow")}>
+                                    <ArrowBoldRightIcon />
+                                </div>
+                                <div className={cn("curr-state")}>
+                                    <StatusIndicator statuses={[state]} size={14} />
+                                </div>
+                                <div className={cn("curr-value")}>{roundValue(value, false)}</div>
+                            </div>
+                            <div className={cn("date")}>
+                                {moment.unix(timestamp).format("MMMM D, HH:mm:ss")}
+                            </div>
+                        </>
+                        <div className={cn("dropdown")}>
+                            {i === 0 && (
+                                <Button
+                                    use="link"
+                                    onClick={() => {
+                                        this.toggleExpand();
+                                    }}
+                                >
+                                    {arrowIcon}
+                                </Button>
+                            )}
+                        </div>
+                    </div>
+                )
+            );
+        });
+    }
+
+    toggleExpand = async () => {
+        const { expand } = this.state;
+        this.setState({ expand: !expand });
+    };
+}
+
+export { MetricEvents as default };

--- a/src/Components/MetricEvents/MetricEvents.jsx
+++ b/src/Components/MetricEvents/MetricEvents.jsx
@@ -66,7 +66,7 @@ class MetricEvents extends React.Component<Props, State> {
                             </div>
                         </>
                         <div className={cn("dropdown")}>
-                            {i === 0 && (
+                            {i === 0 && events.length > 1 && (
                                 <Button
                                     use="link"
                                     onClick={() => {

--- a/src/Components/MetricEvents/MetricEvents.less
+++ b/src/Components/MetricEvents/MetricEvents.less
@@ -5,20 +5,6 @@
     margin-top: 5px;
 }
 
-.group {
-    margin: 0 -5px;
-    padding: 10px 5px;
-}
-
-.group:nth-child(odd) {
-    background-color: #f6f6f6;
-}
-
-.header {
-    color: #666;
-    font-style: italic;
-}
-
 .row {
     display: flex;
     align-items: center;
@@ -40,6 +26,22 @@
     width: 300px;
 }
 
+.prev-value,
+.curr-value {
+    width: 60px;
+    font-size: 12px;
+    color: #666;
+}
+
+.prev-value {
+    margin-right: 10px;
+    text-align: right;
+}
+
+.curr-value {
+    margin-left: 10px;
+}
+
 .arrow {
     margin: 0 5px;
 }
@@ -48,7 +50,6 @@
     flex-shrink: 0;
     width: 200px;
 }
-
 .dropdown {
     flex-shrink: 0;
     width: 50px;

--- a/src/Components/MetricEvents/MetricEvents.less
+++ b/src/Components/MetricEvents/MetricEvents.less
@@ -50,6 +50,12 @@
     flex-shrink: 0;
     width: 200px;
 }
+
+.count {
+    flex-shrink: 0;
+    width: 200px;
+}
+
 .dropdown {
     flex-shrink: 0;
     width: 50px;

--- a/src/pages/trigger/trigger.desktop.jsx
+++ b/src/pages/trigger/trigger.desktop.jsx
@@ -52,14 +52,16 @@ class TriggerDesktop extends React.Component<Props, State> {
         events: Array<Event>,
         triggerName: string
     ): {
-        [key: string]: Array<Event>,
+        [key: string]: Array<Array<Event>, Number>,
     } {
         return events.reduce((data, event) => {
             const metric = this.getEventMetricName(event, triggerName);
             if (data[metric]) {
-                data[metric].push(event);
+                data[metric][0].push(event);
+                // eslint-disable-next-line no-param-reassign
+                data[metric][1] += 1;
             } else {
-                data[metric] = [event]; // eslint-disable-line no-param-reassign
+                data[metric] = [[event], 1]; // eslint-disable-line no-param-reassign
             }
             return data;
         }, {});

--- a/src/pages/trigger/trigger.desktop.jsx
+++ b/src/pages/trigger/trigger.desktop.jsx
@@ -1,6 +1,5 @@
 // @flow
 import * as React from "react";
-import Paging from "retail-ui/components/Paging";
 import Center from "retail-ui/components/Center";
 import type { Trigger, TriggerState } from "../../Domain/Trigger";
 import type { Event } from "../../Domain/Event";
@@ -17,14 +16,11 @@ type Props = {|
     trigger: ?Trigger,
     state: ?TriggerState,
     events: Array<Event>,
-    page: number,
-    pageCount: number,
     disableThrottling: (id: string) => void,
     setTriggerMaintenance: (id: string, maintenance: Maintenance) => void,
     setMetricMaintenance: (id: string, maintenance: Maintenance, metric: string) => void,
     removeMetric: (id: string, metric: string) => void,
     removeNoDataMetric: (id: string) => void,
-    onPageChange: ({ page: number }) => {},
     loading: boolean,
     error?: string,
 |};
@@ -75,14 +71,11 @@ class TriggerDesktop extends React.Component<Props, State> {
             trigger,
             state,
             events,
-            page,
-            pageCount,
             disableThrottling,
             setTriggerMaintenance,
             setMetricMaintenance,
             removeMetric,
             removeNoDataMetric,
-            onPageChange,
             loading,
             error,
         } = this.props;
@@ -118,7 +111,7 @@ class TriggerDesktop extends React.Component<Props, State> {
                         </Center>
                     ) : (
                         // eslint-disable-next-line no-nested-ternary
-                        <Tabs value={isMetrics ? (page > 1 ? "events" : "state") : "state"}>
+                        <Tabs value={isMetrics ? "state" : "events"}>
                             {isMetrics && trigger.id && (
                                 <Tab id="state" label="Current state">
                                     <MetricList
@@ -150,19 +143,6 @@ class TriggerDesktop extends React.Component<Props, State> {
                                     <EventList
                                         items={TriggerDesktop.composeEvents(events, trigger.name)}
                                     />
-                                    {pageCount > 1 && (
-                                        <div style={{ paddingTop: 20 }}>
-                                            <Paging
-                                                caption="Next page"
-                                                activePage={page}
-                                                pagesCount={pageCount}
-                                                onPageChange={newPage =>
-                                                    onPageChange({ page: newPage })
-                                                }
-                                                withoutNavigationHint
-                                            />
-                                        </div>
-                                    )}
                                 </Tab>
                             )}
                         </Tabs>

--- a/src/pages/trigger/trigger.jsx
+++ b/src/pages/trigger/trigger.jsx
@@ -1,7 +1,11 @@
 // @flow
 import * as React from "react";
+<<<<<<< HEAD
 import queryString from "query-string";
 import type { ContextRouter, useHistory } from "react-router-dom";
+=======
+import type { ContextRouter } from "react-router-dom";
+>>>>>>> feat(trigger.desktop, trigger): removed paging mechanism
 import isEqual from "lodash/isEqual";
 import type { Trigger, TriggerState } from "../../Domain/Trigger";
 import type { Event } from "../../Domain/Event";
@@ -9,15 +13,12 @@ import type { IMoiraApi } from "../../Api/MoiraApi";
 import type { Maintenance } from "../../Domain/Maintenance";
 import { withMoiraApi } from "../../Api/MoiraApiInjection";
 import { setMetricMaintenance, setTriggerMaintenance } from "../../Domain/Maintenance";
-import transformPageFromHumanToProgrammer from "../../logic/transformPageFromHumanToProgrammer";
 
 type Props = ContextRouter & { moiraApi: IMoiraApi };
 
 type State = {
     loading: boolean,
     error: ?string,
-    page: number,
-    pageCount: number,
     trigger: ?Trigger,
     triggerState: ?TriggerState,
     triggerEvents: Array<Event>,
@@ -29,8 +30,6 @@ class TriggerPage extends React.Component<Props, State> {
     state: State = {
         loading: true,
         error: null,
-        page: 1,
-        pageCount: 1,
         trigger: null,
         triggerState: null,
         triggerEvents: [],
@@ -46,15 +45,6 @@ class TriggerPage extends React.Component<Props, State> {
         if (!isEqual(prevLocation, currentLocation)) {
             this.loadData();
         }
-    }
-
-    static parseLocationSearch(search: string): MoiraUrlParams {
-        const START_PAGE = 1;
-        const { page } = queryString.parse(search);
-
-        return {
-            page: Number.isNaN(Number(page)) ? START_PAGE : Math.abs(parseInt(page, 10)),
-        };
     }
 
     static getEventMetricName(event: Event, triggerName: string): string {
@@ -82,15 +72,7 @@ class TriggerPage extends React.Component<Props, State> {
     }
 
     render() {
-        const {
-            loading,
-            error,
-            page,
-            pageCount,
-            trigger,
-            triggerState,
-            triggerEvents,
-        } = this.state;
+        const { loading, error, trigger, triggerState, triggerEvents } = this.state;
         const { view: TriggerView } = this.props;
 
         return (
@@ -98,8 +80,6 @@ class TriggerPage extends React.Component<Props, State> {
                 trigger={trigger}
                 state={triggerState}
                 events={triggerEvents}
-                page={page}
-                pageCount={pageCount}
                 loading={loading}
                 error={error}
                 disableThrottling={this.disableThrottling}
@@ -107,14 +87,12 @@ class TriggerPage extends React.Component<Props, State> {
                 setMetricMaintenance={this.setMetricMaintenance}
                 removeMetric={this.removeMetric}
                 removeNoDataMetric={this.removeNoDataMetric}
-                onPageChange={this.changeLocationSearch}
             />
         );
     }
 
     async loadData() {
-        const { moiraApi, match, location } = this.props;
-        const { page } = TriggerPage.parseLocationSearch(location.search);
+        const { moiraApi, match } = this.props;
         const { id } = match.params;
 
         // ToDo написать проверку id
@@ -123,18 +101,14 @@ class TriggerPage extends React.Component<Props, State> {
             const [trigger, triggerState, triggerEvents] = await Promise.all([
                 moiraApi.getTrigger(id),
                 moiraApi.getTriggerState(id),
-                moiraApi.getTriggerEvents(id, transformPageFromHumanToProgrammer(page)),
+                moiraApi.getTriggerEvents(id),
             ]);
-
-            const pageCount = Math.ceil(triggerEvents.total / triggerEvents.size);
 
             // ToDo написать проверку на превышение страниц
 
             document.title = `Moira - Trigger - ${trigger.name}`;
 
             this.setState({
-                page,
-                pageCount: Number.isNaN(pageCount) ? 1 : pageCount,
                 trigger,
                 triggerState,
                 triggerEvents: triggerEvents.list || [],
@@ -178,21 +152,6 @@ class TriggerPage extends React.Component<Props, State> {
         this.setState({ loading: true });
         await moiraApi.delNoDataMetric(triggerId);
         this.loadData();
-    };
-
-    changeLocationSearch = update => {
-        const { location } = this.props;
-        const locationSearch = TriggerPage.parseLocationSearch(location.search);
-        const history = useHistory();
-        history.push(
-            `?${queryString.stringify(
-                { ...locationSearch, ...update },
-                {
-                    arrayFormat: "index",
-                    encode: true,
-                }
-            )}`
-        );
     };
 }
 

--- a/src/pages/trigger/trigger.jsx
+++ b/src/pages/trigger/trigger.jsx
@@ -104,8 +104,6 @@ class TriggerPage extends React.Component<Props, State> {
                 moiraApi.getTriggerEvents(id),
             ]);
 
-            // ToDo написать проверку на превышение страниц
-
             document.title = `Moira - Trigger - ${trigger.name}`;
 
             this.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,6 +4414,11 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
+detect-passive-events@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/detect-passive-events/-/detect-passive-events-1.0.4.tgz#6ed477e6e5bceb79079735dcd357789d37f9a91a"
+  integrity sha1-btR35uW863kHlzXc01d4nTf5qRo=
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -4884,7 +4889,7 @@ eslint-plugin-prettier@3.0.1:
     prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-react-hooks@^2.5.0:
-  version "2.5.0"
+ version "2.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.0.tgz#c50ab7ca5945ce6d1cf8248d9e185c80b54171b6"
   integrity sha512-bzvdX47Jx847bgAYf0FPX3u1oxU+mKU8tqrpj4UX9A96SbAmj/HVEefEy6rJUog5u8QIlOPTKZcBpGn5kkKfAQ==
 
@@ -9616,6 +9621,15 @@ react-router@5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-scroll-up-button@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/react-scroll-up-button/-/react-scroll-up-button-1.6.4.tgz#9c4c45d1b58f2e4fcf60e44817a170becd25c7ba"
+  integrity sha512-ou/ZLbjAXgXnszmNp9g17XlZBat48V3Oz40ssEcu6dEIM2CVn/yWxej3Y4Fx1LyUtQ1cc/MoWOSXC2dufaiACg==
+  dependencies:
+    detect-passive-events "^1.0.4"
+    prop-types "^15.6.2"
+    tween-functions "^1.2.0"
+
 react-split-pane@^0.1.84:
   version "0.1.85"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.85.tgz#64819946a99b617ffa2d20f6f45a0056b6ee4faa"
@@ -11270,6 +11284,11 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+tween-functions@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tween-functions/-/tween-functions-1.2.0.tgz#1ae3a50e7c60bb3def774eac707acbca73bbc3ff"
+  integrity sha1-GuOlDnxguz3vd06scHrLynO7w/8=
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
**Details**
1. Added expand-collapse button to reduce the scroll time.
2. Removed paging mechanism which resulted in all events to occur under the same metric. 
3. Added `Events count` column, which represents the number of events associated to the metric.
4. Since now all events are rendered on a single page, it would be very uncomfortable UX when there are lots of events. So added `scroll-to-top` button for events list.

**UI changes**
```
Total metrics count: 106
Total events count: 22000+
```
![Peek 2020-03-26 15-234](https://user-images.githubusercontent.com/42354803/77634083-69cba800-6f76-11ea-8965-8eafe4a89c6b.gif)

**Note**

There are **no such performance issues**, though it may look a bit laggy that's because of low GIF quality(10 FPS).

**Related issue**

https://github.com/moira-alert/moira/issues/363