### PR TITLE
fix(trigger list): Change handler prop

### DIFF
--- a/src/pages/trigger-list/trigger-list.desktop.jsx
+++ b/src/pages/trigger-list/trigger-list.desktop.jsx
@@ -45,7 +45,7 @@ class TriggerListDesktop extends React.Component {
                         <Fit>
                             <Toggle
                                 checked={onlyProblems}
-                                onChange={value => onChange({ onlyProblems: value })}
+                                onValueChange={value => onChange({ onlyProblems: value })}
                             />{" "}
                             Only Problems
                         </Fit>


### PR DESCRIPTION
In components library switcher has a property that defines a handler
which will be called when change event raised. Property of component
is called onValueChange. Instead of usage of onValueChange onChange
native event was used that caused error because onChange handler
receives event object instead of boolean.