### PR TITLE
Fix: set maintenances on trigger and filter notifications

### DIFF
--- a/src/Components/MetricList/MetricList.jsx
+++ b/src/Components/MetricList/MetricList.jsx
@@ -147,7 +147,9 @@ export default function MetricList(props: Props): React.Node {
                                 <MaintenanceSelect
                                     maintenance={maintenance}
                                     caption={maintenanceCaption(delta)}
-                                    onSetMaintenance={key => onChange(metric, key)}
+                                    onSetMaintenance={maintenanceValue =>
+                                        onChange(metric, maintenanceValue)
+                                    }
                                 />
                             </div>
                             <div className={cn("author")}>

--- a/src/Components/SubscriptionList/SubscriptionList.jsx
+++ b/src/Components/SubscriptionList/SubscriptionList.jsx
@@ -33,27 +33,18 @@ type State = {
     newSubscription: ?SubscriptionInfo,
     subscriptionEditModalVisible: boolean,
     subscriptionToEdit: ?Subscription,
-    availableTags: string[],
-    filteredSubscription: Subscription[],
+    filterTags: string[],
 };
 
 export default class SubscriptionList extends React.Component<Props, State> {
     props: Props;
-
-    constructor(props: Props) {
-        super(props);
-
-        const { subscriptions } = props;
-        this.state.filteredSubscription = subscriptions;
-        this.state.availableTags = [...new Set(subscriptions.flatMap(i => i.tags))];
-    }
 
     state: State = {
         newSubscriptionModalVisible: false,
         newSubscription: null,
         subscriptionEditModalVisible: false,
         subscriptionToEdit: null,
-        filteredTags: [],
+        filterTags: [],
     };
 
     render(): React.Element<any> {
@@ -63,10 +54,9 @@ export default class SubscriptionList extends React.Component<Props, State> {
             newSubscription,
             subscriptionEditModalVisible,
             subscriptionToEdit,
-            filteredSubscription,
-            filteredTags,
-            availableTags,
+            filterTags,
         } = this.state;
+        const { filteredSubscriptions, availableTags } = this.filterSubscriptions();
 
         return (
             <div>
@@ -88,9 +78,9 @@ export default class SubscriptionList extends React.Component<Props, State> {
                             <Fit>
                                 <TagDropdownSelect
                                     width={280}
-                                    value={filteredTags}
+                                    value={filterTags}
                                     availableTags={availableTags}
-                                    onChange={this.handleFilteredSubscription}
+                                    onChange={this.handleFilterTagsChange}
                                     placeholder=" Filter subscriptions by Tags"
                                 />
                             </Fit>
@@ -98,7 +88,7 @@ export default class SubscriptionList extends React.Component<Props, State> {
                         <div className={cn("items-container")}>
                             <table className={cn("items")}>
                                 <tbody>
-                                    {filteredSubscription.map(subscription =>
+                                    {filteredSubscriptions.map(subscription =>
                                         this.renderSubscriptionRow(subscription)
                                     )}
                                 </tbody>
@@ -141,17 +131,8 @@ export default class SubscriptionList extends React.Component<Props, State> {
         );
     }
 
-    handleFilteredSubscription = (tags: string[]) => {
-        const { subscriptions } = this.props;
-        const filteredSubscription = subscriptions.filter(subscription =>
-            tags.every(x => subscription.tags.includes(x))
-        );
-
-        this.setState({
-            filteredTags: tags,
-            filteredSubscription,
-            availableTags: [...new Set(filteredSubscription.flatMap(i => i.tags))],
-        });
+    handleFilterTagsChange = (tags: string[]) => {
+        this.setState({ filterTags: tags });
     };
 
     handleEditSubscription = (subscription: Subscription) => {
@@ -260,6 +241,22 @@ export default class SubscriptionList extends React.Component<Props, State> {
                 subscriptionToEdit: null,
             });
         }
+    };
+
+    filterSubscriptions = (): {
+        filteredSubscriptions: Subscription[],
+        availableTags: string[],
+    } => {
+        const { subscriptions } = this.props;
+        const { filterTags } = this.state;
+        const filteredSubscriptions = subscriptions.filter(subscription =>
+            filterTags.every(x => subscription.tags.includes(x))
+        );
+
+        return {
+            filteredSubscriptions,
+            availableTags: [...new Set(filteredSubscriptions.flatMap(i => i.tags))],
+        };
     };
 
     renderSubscriptionRow(subscription: Subscription): React.Node {

--- a/src/pages/trigger/trigger.desktop.jsx
+++ b/src/pages/trigger/trigger.desktop.jsx
@@ -21,7 +21,7 @@ type Props = {|
     pageCount: number,
     disableThrottling: (id: string) => void,
     setTriggerMaintenance: (id: string, maintenance: number) => void,
-    setMetricMaintenance: (id: string, maintenance: number, metric: string) => void,
+    setMetricMaintenance: (id: string, metric: string, maintenance: number) => void,
     removeMetric: (id: string, metric: string) => void,
     removeNoDataMetric: (id: string) => void,
     onPageChange: ({ page: number }) => {},
@@ -138,7 +138,7 @@ class TriggerDesktop extends React.Component<Props, State> {
                                         sortingColumn={sortingColumn}
                                         sortingDown={sortingDown}
                                         onChange={(metric, maintenance) => {
-                                            setMetricMaintenance(triggerId, maintenance, metric);
+                                            setMetricMaintenance(triggerId, metric, maintenance);
                                         }}
                                         onRemove={metric => removeMetric(triggerId, metric)}
                                         noDataMerticCount={noDataMerticCount}

--- a/src/pages/trigger/trigger.mobile.jsx
+++ b/src/pages/trigger/trigger.mobile.jsx
@@ -8,7 +8,7 @@ type Props = {|
     state: ?TriggerState,
     disableThrottling: (id: string) => void,
     setTriggerMaintenance: (id: string, maintenance: number) => void,
-    setMetricMaintenance: (id: string, maintenance: number, metric: string) => void,
+    setMetricMaintenance: (id: string, metric: string, maintenance: number) => void,
     removeMetric: (id: string, metric: string) => void,
 |};
 
@@ -30,7 +30,7 @@ export default function TriggerMobile({
             onRemoveMetric={metric => removeMetric(trigger ? trigger.id : "", metric)}
             onThrottlingRemove={() => disableThrottling(trigger ? trigger.id : "")}
             onSetMetricMaintenance={(metric, maintenance) =>
-                setMetricMaintenance(trigger ? trigger.id : "", maintenance, metric)
+                setMetricMaintenance(trigger ? trigger.id : "", metric, maintenance)
             }
             onSetTriggerMaintenance={maintenance =>
                 setTriggerMaintenance(trigger ? trigger.id : "", maintenance)


### PR DESCRIPTION
1. setMaintenance send incorrect key-value order in maintenance body.
2. Notification list don't render added item when search field contains tags.