### PR TITLE
feat: move disabled and remove all buttons on top notifications page

### DIFF
--- a/src/Components/Layout/Layout.tsx
+++ b/src/Components/Layout/Layout.tsx
@@ -14,7 +14,7 @@ type PlateProps = {
 };
 
 type TitleProps = {
-    children: string;
+    children: React.ReactNode;
 };
 
 type ContentProps = {

--- a/src/Containers/NotificationListContainer.tsx
+++ b/src/Containers/NotificationListContainer.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import { Button } from "@skbkontur/react-ui/components/Button";
+import { Gapped } from "@skbkontur/react-ui/components/Gapped";
 import TrashIcon from "@skbkontur/react-icons/Trash";
 import MoiraApi from "../Api/MoiraApi";
 import type { Notification } from "../Domain/Notification";
 import { withMoiraApi } from "../Api/MoiraApiInjection";
 import MoiraServiceStates from "../Domain/MoiraServiceStates";
-import Layout, { LayoutContent, LayoutTitle, LayoutFooter } from "../Components/Layout/Layout";
+import Layout, { LayoutContent, LayoutTitle } from "../Components/Layout/Layout";
 import NotificationList from "../Components/NotificationList/NotificationList";
-import ToggleWithLabel from "../Components/Toggle/Toggle";
 
 type Props = { moiraApi: MoiraApi };
 type State = {
@@ -45,42 +45,32 @@ class NotificationListContainer extends React.Component<Props, State> {
         return (
             <Layout loading={loading} error={error}>
                 <LayoutContent>
-                    <LayoutTitle>{layoutTitle}</LayoutTitle>
+                    <LayoutTitle>
+                        <Gapped gap={10}>
+                            {layoutTitle}
+                            {notifierEnabled ? null : "(Disabled)"}
+                        </Gapped>
+                    </LayoutTitle>
+                    <Gapped gap={20}>
+                        <Button use={"link"} onClick={() => this.enableNotifier(!notifierEnabled)}>
+                            {notifierEnabled ? "Disable notifications" : "Enable notifications"}
+                        </Button>
+                        <Button
+                            use={"link"}
+                            icon={<TrashIcon />}
+                            onClick={this.removeAllNotifications}
+                        >
+                            Remove all
+                        </Button>
+                    </Gapped>
+                    <br />
                     {list && (
                         <NotificationList
                             items={NotificationListContainer.composeNotifications(list)}
-                            onRemove={(id) => {
-                                this.removeNotification(id);
-                            }}
+                            onRemove={this.removeNotification}
                         />
                     )}
                 </LayoutContent>
-                <LayoutFooter>
-                    <div
-                        style={{
-                            display: "flex",
-                            flexDirection: "row",
-                            justifyContent: "space-between",
-                            alignContent: "center",
-                        }}
-                    >
-                        <Button
-                            icon={<TrashIcon />}
-                            onClick={() => {
-                                this.removeAllNotifications();
-                            }}
-                        >
-                            Remove all notifications
-                        </Button>
-                        <ToggleWithLabel
-                            label={
-                                notifierEnabled ? "Notifications enabled" : "Notifications disabled"
-                            }
-                            checked={notifierEnabled}
-                            onChange={(checked) => this.enableNotifier(checked)}
-                        />
-                    </div>
-                </LayoutFooter>
             </Layout>
         );
     }
@@ -114,7 +104,7 @@ class NotificationListContainer extends React.Component<Props, State> {
         }
     }
 
-    async removeNotification(id: string) {
+    removeNotification = async (id: string) => {
         const { moiraApi } = this.props;
         this.setState({ loading: true });
         try {
@@ -125,9 +115,9 @@ class NotificationListContainer extends React.Component<Props, State> {
         } finally {
             this.setState({ loading: false });
         }
-    }
+    };
 
-    async removeAllNotifications() {
+    removeAllNotifications = async () => {
         const { moiraApi } = this.props;
         this.setState({ loading: true });
         try {
@@ -139,7 +129,7 @@ class NotificationListContainer extends React.Component<Props, State> {
         } finally {
             this.setState({ loading: false });
         }
-    }
+    };
 
     async enableNotifier(enable: boolean) {
         const { moiraApi } = this.props;


### PR DESCRIPTION
It was difficult to use buttons when too much notifications on the page.



relative:
[INFRA-5948](https://yt.skbkontur.ru/issue/INFRA-5948) Переделать текст возле элемента switch в уведомлениях
На странице moira/notifications есть swtich, включающий/выключающий уведомления. Сейчас у него меняется лейбл "Notifications disabled"/"Notifications enabled". Предлагаю сделать неизменяемый лейбл "Notifications", потому что сейчас каждый раз спотыкаешься и не сразу можно понять, в каком сейчас состоянии и в каком состоянии будет после нажатия.

[INFRA-5943](https://yt.skbkontur.ru/issue/INFRA-5943) Перенести строку с кнопками над списком уведомлений
На странице moira.notifications, когда много уведомлений, до элементов Notifications enabled и Remove all notifications трудно домотать. Нужно перенести строку с ними над списком уведомлений.


Add "Disable notifications" button and "Remove all" button under title
![image](https://user-images.githubusercontent.com/14935625/132189029-8a2b23be-69ec-4751-9dc0-5e0e7e37010c.png)


if notifications disabled show "Disabled" near title and "Disabled notification" button changed to "Enable notifications". 
![image](https://user-images.githubusercontent.com/14935625/132188790-bac5e4d7-e446-4b80-882a-0a90d459162a.png)
