### PR TITLE
refactoring: remove deprecated package bundle-loader, add dynamic import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /flow-coverage
 /build
 .idea/
+.vscode/

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "@skbkontur/react-stack-layout": "1.0.3",
         "@skbkontur/react-ui": "2.17.4",
         "@skbkontur/react-ui-validations": "1.1.3",
-        "bundle-loader": "0.5.6",
         "color-hash": "1.0.3",
         "date-fns": "2.9.0",
         "dompurify": "2.2.6",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,9 +5,8 @@ import { LangCodes } from "@skbkontur/react-ui/lib/locale";
 import { LocaleContext } from "@skbkontur/react-ui/lib/locale/LocaleContext";
 import MoiraApi from "./Api/MoiraApi";
 import { ApiProvider } from "./Api/MoiraApiInjection";
-import mobile from "./mobile.bundle";
-import desktop from "./desktop.bundle";
 import checkMobile from "./helpers/check-mobile";
+
 import "./style.less";
 
 const root = document.getElementById("root");
@@ -33,16 +32,9 @@ const isMobile = checkMobile(window.navigator.userAgent);
 
 const load = (): void => {
     if (isMobile) {
-        /*
-            bundle-loader заменяет экспорт на свой. Вместо ожидаемого React.Component импортируется функция,
-            возвращающая промис и принимающая коллбек, который будет вызван, когда промис зарезолвится.
-            Из-за этого Флоу кидает ошибку. Специальный комментарий её отключает
-        */
-        // @ts-ignore see above
-        mobile((bundle) => render(bundle.default));
+        import("./mobile.bundle").then((mobile) => render(mobile.default));
     } else {
-        // @ts-ignore see above
-        desktop((bundle) => render(bundle.default));
+        import("./desktop.bundle").then((desktop) => render(desktop.default));
     }
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,16 +18,6 @@ module.exports = {
     module: {
         rules: [
             {
-                test: /\.bundle\.tsx?$/,
-                use: {
-                    loader: "bundle-loader",
-                    options: {
-                        name: "[name]",
-                        lazy: true,
-                    },
-                },
-            },
-            {
                 test: [/\.jsx?$/, /\.tsx?$/],
                 use: ["babel-loader"],
                 exclude: /node_modules/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,13 +3899,6 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bundle-loader@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/bundle-loader/-/bundle-loader-0.5.6.tgz#6c9042e62f1c89941458805a3a479d10f34c71fd"
-  integrity sha512-SUgX+u/LJzlJiuoIghuubZ66eflehnjmqSfh/ib9DTe08sxRJ5F/MhHSjp7GfSJivSp8NWgez4PVNAUuMg7vSg==
-  dependencies:
-    loader-utils "^1.1.0"
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"


### PR DESCRIPTION
Удалил деприкейтед пакет bundler-loader. Вместо этого использовал dynamic imports как советуют в репозитории этого пакета https://github.com/webpack-contrib/bundle-loader/blob/master/README.md

В будущем будет проще переезжать на webpack 5 и новую версию React

