### PR TITLE
fixed deleting metric with forbidden simbols

### DIFF
--- a/src/Api/MoiraApi.ts
+++ b/src/Api/MoiraApi.ts
@@ -412,9 +412,9 @@ export default class MoiraApi {
     }
 
     async delMetric(triggerId: string, metric: string): Promise<void> {
-        const url = `${this.apiUrl}/trigger/${encodeURI(triggerId)}/metrics?name=${encodeURI(
-            metric
-        )}`;
+        const url = `${this.apiUrl}/trigger/${encodeURI(
+            triggerId
+        )}/metrics?name=${encodeURIComponent(metric)}`;
         const response = await fetch(url, {
             method: "DELETE",
             credentials: "same-origin",


### PR DESCRIPTION
# PR Summary
metric names were used in api deleting method with encodeURI, thats why all the names including (& ; # +) were passed without encoding
