### PR TITLE
fix(build): add force pull 'latest' nightly images

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start:dev-proxy": "yarn serve --config webpack.config.dev-proxy.js",
         "start:docker": "npm-run-all --parallel backend start:docker-proxy",
         "start:docker-proxy": "yarn serve --config webpack.config.docker-proxy.js",
-        "backend": "docker-compose -f src/tests/core/api/docker-compose.yml down --rmi all && docker-compose -f src/tests/core/api/docker-compose.yml up",
+        "backend": "docker compose -f src/tests/core/api/docker-compose.yml down --rmi all && docker compose -f src/tests/core/api/docker-compose.yml up",
         "build": "webpack --mode=production",
         "storybook": "cross-env NODE_ENV=development start-storybook dev -p 9001 -c .storybook --ci ",
         "storybook:ci": "yarn storybook --ci --quiet",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start:dev-proxy": "yarn serve --config webpack.config.dev-proxy.js",
         "start:docker": "npm-run-all --parallel backend start:docker-proxy",
         "start:docker-proxy": "yarn serve --config webpack.config.docker-proxy.js",
-        "backend": "docker-compose -f src/tests/core/api/docker-compose.yml up",
+        "backend": "docker-compose -f src/tests/core/api/docker-compose.yml down --rmi all && docker-compose -f src/tests/core/api/docker-compose.yml up",
         "build": "webpack --mode=production",
         "storybook": "cross-env NODE_ENV=development start-storybook dev -p 9001 -c .storybook --ci ",
         "storybook:ci": "yarn storybook --ci --quiet",

--- a/src/tests/core/api/docker-compose.yml
+++ b/src/tests/core/api/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - data:/data
 
   filter:
-    image: moira/filter-nightly
+    image: moira/filter-nightly:latest
     ports:
       - "2003:2003"
     depends_on:
@@ -16,7 +16,7 @@ services:
       - redis:localhost
 
   checker:
-    image: moira/checker-nightly
+    image: moira/checker-nightly:latest
     networks:
       - default
     depends_on:
@@ -26,7 +26,7 @@ services:
       - redis:localhost
 
   notifier:
-    image: moira/notifier-nightly
+    image: moira/notifier-nightly:latest
     depends_on:
       - redis
       - checker
@@ -34,7 +34,7 @@ services:
       - redis:localhost
 
   api:
-    image: moira/api-nightly
+    image: moira/api-nightly:latest
     depends_on:
       - redis
       - checker
@@ -45,7 +45,7 @@ services:
       - balancer
 
   web:
-    image: moira/web2
+    image: moira/web2:latest
     networks:
       - balancer
 


### PR DESCRIPTION
# PR Summary

When starting the service, the latest versions of docker images are not downloaded. This behavior has been fixed. Now, before starting docker, containers and images will be deleted, and then the latest versions of the images will be downloaded.

Feature: update version docker compose from V1 to V2.
