### PR TITLE
replaced crypto.randomUUID with uuidv4

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
         "react-virtualized-auto-sizer": "1.0.20",
         "reflect-metadata": "0.1.13",
         "remark-breaks": "4.0.0",
-        "start-server-and-test": "2.0.3"
+        "start-server-and-test": "2.0.3",
+        "uuid": "9.0.1"
     },
     "devDependencies": {
         "@babel/core": "7.23.3",

--- a/src/hooks/useIds.tsx
+++ b/src/hooks/useIds.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
+import { v4 as uuidv4 } from "uuid";
 
+// Do not using crypto Api cause some opensource users may use Moira in non-secure browser context
 export const useIds = (initialLength: number) => {
-    const [ids, setIds] = useState<string[]>(
-        Array.from({ length: initialLength }, () => crypto.randomUUID())
-    );
+    const [ids, setIds] = useState<string[]>(Array.from({ length: initialLength }, () => uuidv4()));
 
     return [ids, setIds] as const;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11598,6 +11598,11 @@ uuid@^9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 uvu@^0.5.0:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz"


### PR DESCRIPTION
# PR Summary

some opensource users may use Moira in non-secure browser context which is not compatible with crypto Api
