### PR TITLE
feat/subscription transfer btn

### DIFF
--- a/src/Api/MoiraApi.ts
+++ b/src/Api/MoiraApi.ts
@@ -20,6 +20,7 @@ export type SubscriptionCreateInfo = {
     enabled: boolean;
     any_tags: boolean;
     user?: string;
+    team_id?: string;
     id?: string;
     ignore_recoverings: boolean;
     ignore_warnings: boolean;

--- a/src/Components/CreateSubscriptionModal/CreateSubscriptionModal.tsx
+++ b/src/Components/CreateSubscriptionModal/CreateSubscriptionModal.tsx
@@ -5,7 +5,8 @@ import { ValidationContainer } from "@skbkontur/react-ui-validations";
 import { Fill, RowStack } from "@skbkontur/react-stack-layout";
 import { Contact } from "../../Domain/Contact";
 import { omitSubscription } from "../../helpers/omitTypes";
-import SubscriptionEditor, { SubscriptionInfo } from "../SubscriptionEditor/SubscriptionEditor";
+import SubscriptionEditor from "../SubscriptionEditor/SubscriptionEditor";
+import { SubscriptionCreateInfo } from "../../Api/MoiraApi";
 import FileLoader from "../FileLoader/FileLoader";
 import ModalError from "../ModalError/ModalError";
 import { useParams } from "react-router";
@@ -23,7 +24,7 @@ type Props = {
 const CreateSubscriptionModal: React.FC<Props> = ({ tags, contacts, onCancel }) => {
     const isPlottingDefaultOn = useSelector(selectIsPlottingDefaultOn);
 
-    const [subscription, setSubscription] = useState<SubscriptionInfo>({
+    const [subscription, setSubscription] = useState<SubscriptionCreateInfo>({
         any_tags: false,
         sched: createSchedule(WholeWeek),
         tags: [],
@@ -47,7 +48,7 @@ const CreateSubscriptionModal: React.FC<Props> = ({ tags, contacts, onCancel }) 
         isTestingSubscription,
     } = useCreateSubscription(validationContainerRef, subscription, onCancel, setError, teamId);
 
-    const handleChange = (subscription: Partial<SubscriptionInfo>): void => {
+    const handleChange = (subscription: Partial<SubscriptionCreateInfo>): void => {
         setSubscription((prev) => ({ ...prev, ...subscription }));
         setError(null);
     };

--- a/src/Components/SubscriptionEditor/SubscriptionEditor.tsx
+++ b/src/Components/SubscriptionEditor/SubscriptionEditor.tsx
@@ -19,11 +19,9 @@ import styles from "./SubscriptionEditor.less";
 
 const cn = classNames.bind(styles);
 
-export type SubscriptionInfo = Omit<SubscriptionCreateInfo, "user" | "id">;
-
 type TSubscriptionEditorProps = {
-    subscription: Subscription | SubscriptionInfo;
-    onChange: (subscriptionInfo: Partial<SubscriptionInfo>) => void;
+    subscription: Subscription | SubscriptionCreateInfo;
+    onChange: (subscriptionInfo: Partial<SubscriptionCreateInfo>) => void;
     tags: Array<string>;
     contacts: Array<Contact>;
 };

--- a/src/Components/SubscriptionList/SubscriptionList.tsx
+++ b/src/Components/SubscriptionList/SubscriptionList.tsx
@@ -5,6 +5,8 @@ import { SubscriptionRow } from "./SubscriptionRow/SubscriptionRow";
 import ArrowBoldDownIcon from "@skbkontur/react-icons/ArrowBoldDown";
 import ArrowBoldUpIcon from "@skbkontur/react-icons/ArrowBoldUp";
 import { useSortData } from "../../hooks/useSortData";
+import { useAppSelector } from "../../store/hooks";
+import { UIState } from "../../store/selectors";
 import classNames from "classnames/bind";
 
 import styles from "./SubscriptionList.less";
@@ -22,6 +24,8 @@ export const SubscriptionList: React.FC<Props> = ({
     contacts,
     handleEditSubscription,
 }) => {
+    const { isTransferringSubscriptions } = useAppSelector(UIState);
+
     const { sortedData, sortConfig, handleSort } = useSortData(subscriptions, "contacts");
 
     const SortingIcon =
@@ -31,6 +35,7 @@ export const SubscriptionList: React.FC<Props> = ({
             <table className={cn("items")}>
                 <thead>
                     <tr className={cn("header")}>
+                        {isTransferringSubscriptions && <td style={{ position: "absolute" }}></td>}
                         <td className={cn("fold-button-gap")} />
                         <td colSpan={2}>
                             <button

--- a/src/Components/SubscriptionList/SubscriptionRow/SubscriptionRow.less
+++ b/src/Components/SubscriptionList/SubscriptionRow/SubscriptionRow.less
@@ -17,6 +17,10 @@
         border-bottom: 0;
     }
 
+    &:has(td.checkbox-cell:hover) {
+        background-color: transparent;
+    }
+
     position: relative;
 
     &::after {
@@ -32,6 +36,13 @@
     &:hover::after {
         opacity: 1;
     }
+}
+
+.checkbox-cell {
+    position: absolute;
+    left: -18px;
+    top: 50%;
+    transform: translate(-50%, -50%);
 }
 
 .error {
@@ -56,6 +67,10 @@
 
 .tags-cell {
     max-width: 150px;
+}
+
+.hidden {
+    display: none;
 }
 
 .contact {

--- a/src/Components/SubscriptionList/SubscriptionRow/SubscriptionRow.less
+++ b/src/Components/SubscriptionList/SubscriptionRow/SubscriptionRow.less
@@ -69,10 +69,6 @@
     max-width: 150px;
 }
 
-.hidden {
-    display: none;
-}
-
 .contact {
     overflow: hidden;
     white-space: nowrap;
@@ -98,6 +94,14 @@
 
 .tooltip-cell {
     width: 10px;
+}
+
+.focused {
+    div {
+        div {
+            box-shadow: inset 0 0 0 1px #fff, 0 0 0 2px #1f87ef;
+        }
+    }
 }
 
 @media screen and (min-width: @breakpoint) {

--- a/src/Components/SubscriptionList/SubscriptionRow/SubscriptionRow.tsx
+++ b/src/Components/SubscriptionList/SubscriptionRow/SubscriptionRow.tsx
@@ -78,6 +78,10 @@ export const SubscriptionRow: React.FC<SubscriptionRowProps> = ({
                     className={cn("checkbox-cell")}
                 >
                     <Checkbox
+                        className={cn({
+                            focused:
+                                isTransferringSubscriptions && !transferingSubscriptions.length,
+                        })}
                         checked={transferingSubscriptions.includes(subscription)}
                         onClick={() => {
                             dispatch(toggleSubscriptionTransfer(subscription));

--- a/src/Components/SubscriptionList/SubscriptionRow/SubscriptionRow.tsx
+++ b/src/Components/SubscriptionList/SubscriptionRow/SubscriptionRow.tsx
@@ -8,6 +8,10 @@ import HelpTooltip from "../../HelpTooltip/HelpTooltip";
 import queryString from "query-string";
 import ArrowChevronUpIcon from "@skbkontur/react-icons/ArrowChevronUp";
 import ArrowChevronDownIcon from "@skbkontur/react-icons/ArrowChevronDown";
+import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+import { UIState } from "../../../store/selectors";
+import { Checkbox } from "@skbkontur/react-ui/components/Checkbox";
+import { toggleSubscriptionTransfer } from "../../../store/Reducers/UIReducer.slice";
 import classNames from "classnames/bind";
 
 import styles from "./SubscriptionRow.less";
@@ -25,6 +29,8 @@ export const SubscriptionRow: React.FC<SubscriptionRowProps> = ({
     contacts,
     onEditSubscription,
 }) => {
+    const { isTransferringSubscriptions, transferingSubscriptions } = useAppSelector(UIState);
+    const dispatch = useAppDispatch();
     const [isExpanded, setIsExpanded] = useState(false);
 
     const toggleExpand = () => {
@@ -64,6 +70,21 @@ export const SubscriptionRow: React.FC<SubscriptionRowProps> = ({
             className={cn(rowClassName)}
             onClick={() => onEditSubscription(subscription)}
         >
+            {isTransferringSubscriptions && (
+                <td
+                    onClick={(event) => {
+                        event.stopPropagation();
+                    }}
+                    className={cn("checkbox-cell")}
+                >
+                    <Checkbox
+                        checked={transferingSubscriptions.includes(subscription)}
+                        onClick={() => {
+                            dispatch(toggleSubscriptionTransfer(subscription));
+                        }}
+                    />
+                </td>
+            )}
             <td className={cn("showMore-button-cell")}>
                 {isExpanded ? (
                     <ArrowChevronUpIcon onClick={(event) => handleCollapse(event)} />
@@ -97,12 +118,10 @@ export const SubscriptionRow: React.FC<SubscriptionRowProps> = ({
             )}
             {areAnyDisruptedSubs && (
                 <td className={cn("tooltip-cell")}>
-                    (
                     <HelpTooltip trigger="hover">
                         It seems that this subscription is broken, please set up the delivery
                         channel.
                     </HelpTooltip>
-                    )
                 </td>
             )}
         </tr>

--- a/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.less
+++ b/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.less
@@ -1,0 +1,8 @@
+@import "~styles/variables.less";
+@import "~styles/mixins.less";
+
+.transfer-btn {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.less
+++ b/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.less
@@ -6,3 +6,9 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.team-checkbox {
+    display: flex;
+    align-items: center;
+    padding: 0;
+}

--- a/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.tsx
+++ b/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.tsx
@@ -6,6 +6,8 @@ import { MenuItem } from "@skbkontur/react-ui/components/MenuItem";
 import { ThemeContext, ThemeFactory } from "@skbkontur/react-ui";
 import { useParams } from "react-router";
 import { Button } from "@skbkontur/react-ui/components/Button";
+import { useAppSelector } from "../../store/hooks";
+import { UIState } from "../../store/selectors";
 import classNames from "classnames/bind";
 
 import styles from "./TransferSubscriptionsTeamSelect.less";
@@ -24,12 +26,13 @@ export const TransferSubscriptionsTeamSelect: React.FC<ITransferSubscriptionsTea
     handleSetTeamToTransfer,
 }) => {
     const { teamId: currentTeamId } = useParams<{ teamId: string }>();
+    const { isTransferringSubscriptions } = useAppSelector(UIState);
 
     return (
         <DropdownMenu
             caption={({ openMenu }) => (
                 <Button width={180} className={cn("transfer-btn")} onClick={() => openMenu()}>
-                    {teamToTransfer
+                    {teamToTransfer && isTransferringSubscriptions
                         ? `Transfering to: ${teamToTransfer.name}`
                         : "Transfer subscriptions"}
                 </Button>
@@ -48,10 +51,7 @@ export const TransferSubscriptionsTeamSelect: React.FC<ITransferSubscriptionsTea
                         >
                             <MenuItem>
                                 <Checkbox
-                                    style={{
-                                        alignItems: "center",
-                                        padding: "0",
-                                    }}
+                                    className={cn("team-checkbox")}
                                     checked={teamToTransfer?.id === team.id}
                                     onValueChange={() => handleSetTeamToTransfer(team)}
                                 >

--- a/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.tsx
+++ b/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { DropdownMenu, MenuHeader, MenuSeparator } from "@skbkontur/react-ui";
+import { Checkbox } from "@skbkontur/react-ui/components/Checkbox";
+import { Team } from "../../Domain/Team";
+import { MenuItem } from "@skbkontur/react-ui/components/MenuItem";
+import { ThemeContext, ThemeFactory } from "@skbkontur/react-ui";
+import { useParams } from "react-router";
+import { Button } from "@skbkontur/react-ui/components/Button";
+import classNames from "classnames/bind";
+
+import styles from "./TransferSubscriptionsTeamSelect.less";
+
+const cn = classNames.bind(styles);
+
+interface ITransferSubscriptionsTeamSelectProps {
+    teams: Team[];
+    teamToTransfer: Team | null;
+    handleSetTeamToTransfer: (team: Team) => void;
+}
+
+export const TransferSubscriptionsTeamSelect: React.FC<ITransferSubscriptionsTeamSelectProps> = ({
+    teams,
+    teamToTransfer,
+    handleSetTeamToTransfer,
+}) => {
+    const { currentTeamId } = useParams<{ currentTeamId: string }>();
+
+    return (
+        <DropdownMenu
+            caption={({ openMenu }) => (
+                <Button width={180} className={cn("transfer-btn")} onClick={() => openMenu()}>
+                    {teamToTransfer
+                        ? `Transfering to: ${teamToTransfer.name}`
+                        : "Transfer subscriptions"}
+                </Button>
+            )}
+        >
+            <MenuHeader>Select the team to transfer subscriptions to</MenuHeader>
+            <MenuSeparator />
+            {teams.map((team) => {
+                return (
+                    team.id !== currentTeamId && (
+                        <ThemeContext.Provider
+                            key={team.id}
+                            value={ThemeFactory.create({
+                                menuItemHoverBg: "initial",
+                            })}
+                        >
+                            <MenuItem>
+                                <Checkbox
+                                    style={{
+                                        alignItems: "center",
+                                        padding: "0",
+                                    }}
+                                    checked={teamToTransfer?.id === team.id}
+                                    onValueChange={() => handleSetTeamToTransfer(team)}
+                                >
+                                    {team.name}
+                                </Checkbox>
+                            </MenuItem>
+                        </ThemeContext.Provider>
+                    )
+                );
+            })}
+        </DropdownMenu>
+    );
+};

--- a/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.tsx
+++ b/src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.tsx
@@ -23,7 +23,7 @@ export const TransferSubscriptionsTeamSelect: React.FC<ITransferSubscriptionsTea
     teamToTransfer,
     handleSetTeamToTransfer,
 }) => {
-    const { currentTeamId } = useParams<{ currentTeamId: string }>();
+    const { teamId: currentTeamId } = useParams<{ teamId: string }>();
 
     return (
         <DropdownMenu

--- a/src/Containers/SettingsContainer.tsx
+++ b/src/Containers/SettingsContainer.tsx
@@ -83,6 +83,7 @@ const SettingsContainer: FC<ISettingsContainerProps> = ({ isTeamMember, history 
                 )}
                 {settings && tags && (
                     <SubscriptionListContainer
+                        teams={teams}
                         tags={tags.list}
                         contacts={settings.contacts}
                         subscriptions={settings.subscriptions}

--- a/src/Containers/SubscriptionListContainer/SubscriptionListContainer.less
+++ b/src/Containers/SubscriptionListContainer/SubscriptionListContainer.less
@@ -21,10 +21,11 @@
     align-items: baseline;
 }
 
-.apply-transfer-btn {
+.transfer-btns {
     display: flex;
     justify-content: end;
     margin-top: 18px;
+    gap: 10px;
 }
 
 @media screen and (max-width: @breakpoint) {

--- a/src/Containers/SubscriptionListContainer/SubscriptionListContainer.less
+++ b/src/Containers/SubscriptionListContainer/SubscriptionListContainer.less
@@ -1,4 +1,4 @@
-@import '~styles/variables.less';
+@import "~styles/variables.less";
 
 .header {
     font-size: 18px;
@@ -7,25 +7,29 @@
 }
 
 .subscriptionBtnContainer {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(auto,  1fr));
-  grid-auto-flow: column;
-  grid-gap: 5px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(auto, 1fr));
+    grid-auto-flow: column;
+    grid-gap: 5px;
 }
 
 .row {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: baseline;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: baseline;
 }
 
-@media screen and (max-width:  @breakpoint) {
-  .subscriptionBtnContainer {
-    grid-template-columns:  1fr;
-    grid-auto-flow: row;
-  }
+.apply-transfer-btn {
+    display: flex;
+    justify-content: end;
+    margin-top: 18px;
 }
 
-
+@media screen and (max-width: @breakpoint) {
+    .subscriptionBtnContainer {
+        grid-template-columns: 1fr;
+        grid-auto-flow: row;
+    }
+}

--- a/src/Containers/SubscriptionListContainer/SubscriptionListContainer.tsx
+++ b/src/Containers/SubscriptionListContainer/SubscriptionListContainer.tsx
@@ -150,7 +150,7 @@ export const SubscriptionListContainer: React.FC<Props> = ({
                             >
                                 Add subscription
                             </Button>
-                            {teams && (
+                            {teams && teams?.length !== 0 && (
                                 <TransferSubscriptionsTeamSelect
                                     teams={teams}
                                     teamToTransfer={teamToTransfer}

--- a/src/Containers/SubscriptionListContainer/SubscriptionListContainer.tsx
+++ b/src/Containers/SubscriptionListContainer/SubscriptionListContainer.tsx
@@ -36,7 +36,7 @@ interface Props {
 }
 
 const applyTransferButtonHintText =
-    "There are should be no remaining subscriptions outside of the transfering subscriptions that still contain any of the contacts being transferred";
+    "Remaining subscriptions and subscriptions to be transferred must not share contacts";
 
 export const SubscriptionListContainer: React.FC<Props> = ({
     tags,

--- a/src/Containers/SubscriptionListContainer/SubscriptionListContainer.tsx
+++ b/src/Containers/SubscriptionListContainer/SubscriptionListContainer.tsx
@@ -35,6 +35,9 @@ interface Props {
     subscriptions: Subscription[];
 }
 
+const applyTransferButtonHintText =
+    "There are should be no remaining subscriptions outside of the transfering subscriptions that still contain any of the contacts being transferred";
+
 export const SubscriptionListContainer: React.FC<Props> = ({
     tags,
     teams,
@@ -98,8 +101,9 @@ export const SubscriptionListContainer: React.FC<Props> = ({
         dispatch(setIsTransferringSubscriptions(true));
     };
 
-    const contactIDsToTransfer = new Set(
-        transferingSubscriptions.flatMap((subscription) => subscription.contacts)
+    const contactIDsToTransfer = useMemo(
+        () => new Set(transferingSubscriptions.flatMap((subscription) => subscription.contacts)),
+        [transferingSubscriptions]
     );
 
     const handleTransferContactsAndSubscriptions = async () => {
@@ -174,12 +178,10 @@ export const SubscriptionListContainer: React.FC<Props> = ({
                         handleEditSubscription={handleEditSubscription}
                     />
                     {isTransferringSubscriptions && (
-                        <div className={cn("apply-transfer-btn")}>
+                        <div className={cn("transfer-btns")}>
                             <Hint
                                 text={
-                                    isApplyTransferButtonDisabled
-                                        ? "There are should be no remaining subscriptions outside of the transfering subscriptions that still contain any of the contacts being transferred"
-                                        : ""
+                                    isApplyTransferButtonDisabled ? applyTransferButtonHintText : ""
                                 }
                             >
                                 <Button
@@ -190,6 +192,15 @@ export const SubscriptionListContainer: React.FC<Props> = ({
                                     Apply transfer
                                 </Button>
                             </Hint>
+                            <Button
+                                onClick={() => {
+                                    dispatch(setIsTransferringSubscriptions(false));
+                                    setTeamToTransfer(null);
+                                }}
+                                use="danger"
+                            >
+                                Cancel
+                            </Button>
                         </div>
                     )}
                 </>

--- a/src/Containers/SubscriptionListContainer/SubscriptionListContainer.tsx
+++ b/src/Containers/SubscriptionListContainer/SubscriptionListContainer.tsx
@@ -1,32 +1,54 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { Button } from "@skbkontur/react-ui/components/Button";
 import AddIcon from "@skbkontur/react-icons/Add";
 import { Subscription } from "../../Domain/Subscription";
 import { Contact } from "../../Domain/Contact";
 import SubscriptionEditModal from "../../Components/SubscriptionEditModal/SubscriptionEditModal";
 import CreateSubscriptionModal from "../../Components/CreateSubscriptionModal/CreateSubscriptionModal";
-import type { SubscriptionInfo } from "../../Components/SubscriptionEditor/SubscriptionEditor";
 import { SubscriptionList } from "../../Components/SubscriptionList/SubscriptionList";
 import { AddSubscriptionMessage } from "../../Components/AddSubscribtionMessage/AddSubscribtionMessage";
 import { ModalType } from "../../Domain/Global";
 import { FilterSubscriptionButtons } from "./Components/FilterSubscriptionButtons";
 import { useFilterSubscriptions } from "../../hooks/useFilterSubscriptions";
+import { Hint } from "@skbkontur/react-ui";
+import { Team } from "../../Domain/Team";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import {
+    setIsTransferringSubscriptions,
+    setTransferingSubscriptions,
+} from "../../store/Reducers/UIReducer.slice";
+import { UIState } from "../../store/selectors";
+import { BaseApi } from "../../services/BaseApi";
+import { useTransferContactsToTeam } from "../../hooks/useTransferContactsToTeam";
+import { useTransferSubscriptionsToTeam } from "../../hooks/useTransferSubscriptionsToTeam";
+import { TransferSubscriptionsTeamSelect } from "../../Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect";
 import classNames from "classnames/bind";
 
 import styles from "./SubscriptionListContainer.less";
 
 const cn = classNames.bind(styles);
 
-export type { SubscriptionInfo };
-
 interface Props {
     tags: string[];
+    teams?: Team[];
     contacts: Contact[];
     subscriptions: Subscription[];
 }
 
-export const SubscriptionListContainer: React.FC<Props> = ({ tags, contacts, subscriptions }) => {
+export const SubscriptionListContainer: React.FC<Props> = ({
+    tags,
+    teams,
+    contacts,
+    subscriptions,
+}) => {
+    const dispatch = useAppDispatch();
+    const { isTransferringSubscriptions, transferingSubscriptions } = useAppSelector(UIState);
+
+    const { transferContactsToTeam } = useTransferContactsToTeam();
+    const { transferSubscriptionsToTeam } = useTransferSubscriptionsToTeam();
+
     const [subscriptionToEdit, setSubscriptionToEdit] = useState<Subscription | null>(null);
+    const [teamToTransfer, setTeamToTransfer] = useState<Team | null>(null);
 
     const [modalVisibility, setModalVisibility] = useState({
         [ModalType.subscriptionEditModal]: false,
@@ -66,6 +88,53 @@ export const SubscriptionListContainer: React.FC<Props> = ({ tags, contacts, sub
         openModal(ModalType.newSubscriptionModal);
     };
 
+    const handleSetTeamToTransfer = (team: Team) => {
+        if (team.id === teamToTransfer?.id) {
+            setTeamToTransfer(null);
+            dispatch(setIsTransferringSubscriptions(false));
+            return;
+        }
+        setTeamToTransfer(team);
+        dispatch(setIsTransferringSubscriptions(true));
+    };
+
+    const contactIDsToTransfer = new Set(
+        transferingSubscriptions.flatMap((subscription) => subscription.contacts)
+    );
+
+    const handleTransferContactsAndSubscriptions = async () => {
+        if (!teamToTransfer) {
+            return;
+        }
+
+        const contactsToTransfer = contacts.filter((contact) =>
+            contactIDsToTransfer.has(contact.id)
+        );
+
+        await transferContactsToTeam(contactsToTransfer, teamToTransfer?.id);
+        await transferSubscriptionsToTeam(transferingSubscriptions, teamToTransfer?.id);
+
+        dispatch(BaseApi.util.invalidateTags(["UserSettings", "TeamSettings"]));
+        dispatch(setIsTransferringSubscriptions(false));
+        dispatch(setTransferingSubscriptions([]));
+        setTeamToTransfer(null);
+    };
+
+    const hasRemainingSubscriptionsWithTransferredContacts = useMemo(
+        () =>
+            subscriptions.some((subscription) => {
+                if (transferingSubscriptions.includes(subscription)) {
+                    return false;
+                }
+
+                return subscription.contacts.some((contact) => contactIDsToTransfer.has(contact));
+            }),
+        [transferingSubscriptions]
+    );
+
+    const isApplyTransferButtonDisabled =
+        hasRemainingSubscriptionsWithTransferredContacts || !transferingSubscriptions.length;
+
     return (
         <>
             {subscriptions.length > 0 ? (
@@ -81,6 +150,13 @@ export const SubscriptionListContainer: React.FC<Props> = ({ tags, contacts, sub
                             >
                                 Add subscription
                             </Button>
+                            {teams && (
+                                <TransferSubscriptionsTeamSelect
+                                    teams={teams}
+                                    teamToTransfer={teamToTransfer}
+                                    handleSetTeamToTransfer={handleSetTeamToTransfer}
+                                />
+                            )}
                             <FilterSubscriptionButtons
                                 contacts={contacts}
                                 filterContactIDs={filterContactIDs}
@@ -97,6 +173,25 @@ export const SubscriptionListContainer: React.FC<Props> = ({ tags, contacts, sub
                         contacts={contacts}
                         handleEditSubscription={handleEditSubscription}
                     />
+                    {isTransferringSubscriptions && (
+                        <div className={cn("apply-transfer-btn")}>
+                            <Hint
+                                text={
+                                    isApplyTransferButtonDisabled
+                                        ? "There are should be no remaining subscriptions outside of the transfering subscriptions that still contain any of the contacts being transferred"
+                                        : ""
+                                }
+                            >
+                                <Button
+                                    disabled={isApplyTransferButtonDisabled}
+                                    onClick={handleTransferContactsAndSubscriptions}
+                                    use="primary"
+                                >
+                                    Apply transfer
+                                </Button>
+                            </Hint>
+                        </div>
+                    )}
                 </>
             ) : (
                 <AddSubscriptionMessage onAddSubscription={handleAddSubscription} />

--- a/src/hooks/useCreateSubscription.tsx
+++ b/src/hooks/useCreateSubscription.tsx
@@ -5,13 +5,13 @@ import {
     useTestSubscriptionMutation,
 } from "../services/SubscriptionsApi";
 import { useCreateTeamSubscriptionMutation } from "../services/TeamsApi";
-import { SubscriptionInfo } from "../Components/SubscriptionEditor/SubscriptionEditor";
+import type { SubscriptionCreateInfo } from "../Api/MoiraApi";
 import { useAppDispatch } from "../store/hooks";
 import { BaseApi } from "../services/BaseApi";
 
 export const useCreateSubscription = (
     validationContainer: React.RefObject<ValidationContainer>,
-    subscription: SubscriptionInfo | null,
+    subscription: SubscriptionCreateInfo | null,
     onCancel: () => void,
     setError: (error: string) => void,
     teamId?: string

--- a/src/hooks/useTransferContactsToTeam.tsx
+++ b/src/hooks/useTransferContactsToTeam.tsx
@@ -1,0 +1,24 @@
+import { useUpdateContactMutation } from "../services/ContactApi";
+import { Contact } from "../Domain/Contact";
+import { useCallback } from "react";
+
+export const useTransferContactsToTeam = () => {
+    const [updateContact] = useUpdateContactMutation();
+
+    const transferContactsToTeam = useCallback(async (contacts: Contact[], teamId: string): Promise<
+        void
+    > => {
+        await Promise.all(
+            contacts.map(async (contact) => {
+                const { user, ...contactWithoutUser } = contact;
+                const updatedContact = {
+                    ...contactWithoutUser,
+                    team_id: teamId,
+                };
+                await updateContact(updatedContact);
+            })
+        );
+    }, []);
+
+    return { transferContactsToTeam };
+};

--- a/src/hooks/useTransferSubscriptionsToTeam.tsx
+++ b/src/hooks/useTransferSubscriptionsToTeam.tsx
@@ -1,0 +1,25 @@
+import { useUpdateSubscriptionMutation } from "../services/SubscriptionsApi";
+import { Subscription } from "../Domain/Subscription";
+import { useCallback } from "react";
+
+export const useTransferSubscriptionsToTeam = () => {
+    const [updateSubscription] = useUpdateSubscriptionMutation();
+
+    const transferSubscriptionsToTeam = useCallback(
+        async (subscriptions: Subscription[], teamId: string): Promise<void> => {
+            await Promise.all(
+                subscriptions.map(async (subscription) => {
+                    const updatedSubscription = {
+                        ...subscription,
+                        user: "",
+                        team_id: teamId,
+                    };
+                    await updateSubscription(updatedSubscription);
+                })
+            );
+        },
+        []
+    );
+
+    return { transferSubscriptionsToTeam };
+};

--- a/src/hooks/useUpdateContact.tsx
+++ b/src/hooks/useUpdateContact.tsx
@@ -2,6 +2,8 @@ import { ValidationContainer } from "@skbkontur/react-ui-validations";
 import { Contact } from "../Domain/Contact";
 import { useTestContactMutation, useUpdateContactMutation } from "../services/ContactApi";
 import { validateForm } from "../helpers/validations";
+import { useAppDispatch } from "../store/hooks";
+import { BaseApi } from "../services/BaseApi";
 
 export const useUpdateContact = (
     validationContainer: React.RefObject<ValidationContainer>,
@@ -12,6 +14,7 @@ export const useUpdateContact = (
 ) => {
     const [updateContact, { isLoading: isUpdating }] = useUpdateContactMutation();
     const [testContact, { isLoading: isTesting }] = useTestContactMutation();
+    const dispatch = useAppDispatch();
 
     const handleUpdateContact = async (testAfterUpdate?: boolean) => {
         const validationSuccess = await validateForm(validationContainer);
@@ -29,12 +32,12 @@ export const useUpdateContact = (
             }
             await updateContact({
                 ...contact,
-                isTeamContact: !!teamId,
                 handleLoadingLocally: true,
                 handleErrorLocally: true,
             }).unwrap();
 
             onCancel();
+            dispatch(BaseApi.util.invalidateTags(teamId ? ["TeamSettings"] : ["UserSettings"]));
         } catch (error) {
             setError(error);
         }

--- a/src/hooks/useUpdateSubscription.tsx
+++ b/src/hooks/useUpdateSubscription.tsx
@@ -5,6 +5,8 @@ import {
     useUpdateSubscriptionMutation,
 } from "../services/SubscriptionsApi";
 import { Subscription } from "../Domain/Subscription";
+import { useAppDispatch } from "../store/hooks";
+import { BaseApi } from "../services/BaseApi";
 
 export const useUpdateSubscription = (
     validationContainer: React.RefObject<ValidationContainer>,
@@ -18,6 +20,7 @@ export const useUpdateSubscription = (
         { isLoading: isUpdatingSubscription },
     ] = useUpdateSubscriptionMutation();
     const [testSubscription, { isLoading: isTestingSubscription }] = useTestSubscriptionMutation();
+    const dispatch = useAppDispatch();
 
     const handleUpdateSubscription = async (testAfterUpdate?: boolean): Promise<void> => {
         if (!(await validateForm(validationContainer))) {
@@ -33,12 +36,12 @@ export const useUpdateSubscription = (
             }
             await updateSubscription({
                 ...subscription,
-                isTeamSubscription: !!teamId,
                 handleLoadingLocally: true,
                 handleErrorLocally: true,
             }).unwrap();
 
             onCancel();
+            dispatch(BaseApi.util.invalidateTags(teamId ? ["TeamSettings"] : ["UserSettings"]));
         } catch (error) {
             setError(error);
         }

--- a/src/services/ContactApi.ts
+++ b/src/services/ContactApi.ts
@@ -15,27 +15,19 @@ export const ContactApi = BaseApi.injectEndpoints({
         }),
         updateContact: builder.mutation<
             Contact,
-            CustomBaseQueryArgs<
-                Partial<Contact> & Pick<Contact, "id"> & { isTeamContact?: boolean }
-            >
+            CustomBaseQueryArgs<Partial<Contact> & Pick<Contact, "id">>
         >({
-            query: ({
-                id,
-                handleErrorLocally,
-                handleLoadingLocally,
-                isTeamContact,
-                ...contact
-            }) => ({
+            query: ({ id, handleErrorLocally, handleLoadingLocally, ...contact }) => ({
                 url: `contact/${id}`,
                 method: "PUT",
                 credentials: "same-origin",
                 body: JSON.stringify(contact),
             }),
-            invalidatesTags: (_result, error, { isTeamContact }) => {
+            invalidatesTags: (_result, error) => {
                 if (error) {
                     return [];
                 }
-                return ["Contacts", isTeamContact ? "TeamSettings" : "UserSettings"];
+                return ["Contacts"];
             },
         }),
         testContact: builder.mutation<void, CustomBaseQueryArgs<{ id: string }>>({

--- a/src/services/SubscriptionsApi.ts
+++ b/src/services/SubscriptionsApi.ts
@@ -22,26 +22,18 @@ export const SubscriptionsApi = BaseApi.injectEndpoints({
                 credentials: "same-origin",
             }),
         }),
-        updateSubscription: builder.mutation<
-            Subscription,
-            CustomBaseQueryArgs<Subscription & { isTeamSubscription?: boolean }>
-        >({
-            query: ({
-                isTeamSubscription,
-                handleLoadingLocally,
-                handleErrorLocally,
-                ...subscription
-            }) => ({
+        updateSubscription: builder.mutation<Subscription, CustomBaseQueryArgs<Subscription>>({
+            query: ({ handleLoadingLocally, handleErrorLocally, ...subscription }) => ({
                 url: `subscription/${encodeURIComponent(subscription.id)}`,
                 method: "PUT",
                 credentials: "same-origin",
                 body: JSON.stringify(subscription),
             }),
-            invalidatesTags: (_result, error, { isTeamSubscription }) => {
+            invalidatesTags: (_result, error) => {
                 if (error) {
                     return [];
                 }
-                return ["TagStats", isTeamSubscription ? "TeamSettings" : "UserSettings"];
+                return ["TagStats"];
             },
         }),
         deleteSubscription: builder.mutation<

--- a/src/store/Reducers/UIReducer.slice.ts
+++ b/src/store/Reducers/UIReducer.slice.ts
@@ -1,15 +1,20 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { Subscription } from "../../Domain/Subscription";
 
 interface IUIState {
     isLoading: boolean;
     error: string | null;
     isNewFrontendVersionAvailable: boolean;
+    isTransferringSubscriptions: boolean;
+    transferingSubscriptions: Subscription[];
 }
 
 const initialState: IUIState = {
     isLoading: false,
     error: null,
     isNewFrontendVersionAvailable: false,
+    isTransferringSubscriptions: false,
+    transferingSubscriptions: [],
 };
 
 export const UISlice = createSlice({
@@ -25,9 +30,47 @@ export const UISlice = createSlice({
         updateServiceWorker: (state) => {
             state.isNewFrontendVersionAvailable = true;
         },
+        setIsTransferringSubscriptions: (state, action: PayloadAction<boolean>) => {
+            state.isTransferringSubscriptions = action.payload;
+        },
+        setTransferingSubscriptions: (state, action: PayloadAction<Subscription[]>) => {
+            state.transferingSubscriptions = action.payload;
+        },
+        addSubscriptionToTransfer: (state, action: PayloadAction<Subscription>) => {
+            if (!state.transferingSubscriptions.includes(action.payload)) {
+                state.transferingSubscriptions.push(action.payload);
+            }
+        },
+        removeSubscriptionFromTransfer: (state, action: PayloadAction<string>) => {
+            const index = state.transferingSubscriptions.findIndex(
+                (subscription) => subscription.id === action.payload
+            );
+            if (index !== -1) {
+                state.transferingSubscriptions.splice(index, 1);
+            }
+        },
+        toggleSubscriptionTransfer: (state, action: PayloadAction<Subscription>) => {
+            const existingIndex = state.transferingSubscriptions.findIndex(
+                (subscription) => subscription.id === action.payload.id
+            );
+            if (existingIndex !== -1) {
+                state.transferingSubscriptions.splice(existingIndex, 1);
+            } else {
+                state.transferingSubscriptions.push(action.payload);
+            }
+        },
     },
 });
 
-export const { toggleLoading, setError, updateServiceWorker } = UISlice.actions;
+export const {
+    toggleLoading,
+    setError,
+    updateServiceWorker,
+    setIsTransferringSubscriptions,
+    setTransferingSubscriptions,
+    addSubscriptionToTransfer,
+    removeSubscriptionFromTransfer,
+    toggleSubscriptionTransfer,
+} = UISlice.actions;
 
 export default UISlice.reducer;


### PR DESCRIPTION
# PR Summary

Added an ability to transfer own subscriptions to selected team

- [TeamSelector component](https://github.com/moira-alert/web2.0/pull/528/files#:~:text=src/Components/TransferSubscriptionsTeamSelect/TransferSubscriptionsTeamSelect.tsx)
- before transfering subscription, all included contacts should be transferred first, added corresponding hooks [to transfer subscriptions](https://github.com/moira-alert/web2.0/pull/528/files#:~:text=src/hooks/useTransferSubscriptionsToTeam.tsx) and [contacts](https://github.com/moira-alert/web2.0/pull/528/files#:~:text=src/hooks/useTransferContactsToTeam.tsx)
- added [reducers](https://github.com/moira-alert/web2.0/pull/528/files#:~:text=src/store/Reducers/UIReducer.slice.ts) to work with state
- There are should be no remaining subscriptions outside of the transfering subscriptions that still contain any of the contacts being transferred, so disabling apply transfer button via [variable](https://github.com/moira-alert/web2.0/pull/528/files#:~:text=const%20hasRemainingSubscriptionsWithTransferredContacts)
