### PR TITLE
fix/read_only_mode_trigger_delete

### DIFF
--- a/src/pages/trigger/trigger.tsx
+++ b/src/pages/trigger/trigger.tsx
@@ -54,8 +54,12 @@ const TriggerPage: React.FC<TriggerProps> = ({ view: TriggerView }) => {
     const handleRemoveNoDataMetric = async () => await deleteNoDataMetrics(triggerId);
 
     const handleDeleteTrigger = async () => {
-        await deleteTrigger(triggerId);
-        history.push(getPageLink("index"));
+        try {
+            await deleteTrigger(triggerId).unwrap();
+            history.push(getPageLink("index"));
+        } catch {
+            return;
+        }
     };
 
     useEffect(() => {


### PR DESCRIPTION
# PR Summary

before: history.push was executed regardless of the server response,
now: history.push will only be executed if the response is successful

return in catch method cause all errors are handled in macro level
